### PR TITLE
Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
+  - 1.0
+  - 1.1
   - nightly
 notifications:
   email: false
@@ -14,5 +15,5 @@ git:
 # uncomment the following lines to allow failures on nightly julia
 # (tests will run but not make your overall status red)
 matrix:
- allow_failures:
- - julia: nightly
+  allow_failures:
+    - julia: nightly

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.2.0"
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Hiccup = "9fb69e20-1954-56bb-a84f-559cc56a8ff7"
-IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 Juno = "e5e0dc1b-0480-54bc-9374-aad01c23163d"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,27 @@
+name = "DocSeeker"
+uuid = "33d173f1-3be9-53c5-a697-8225b67db89c"
+version = "0.2.0"
+
+[deps]
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+Hiccup = "9fb69e20-1954-56bb-a84f-559cc56a8ff7"
+IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+Juno = "e5e0dc1b-0480-54bc-9374-aad01c23163d"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+StringDistances = "88034a9c-02f8-509d-84a9-84ec65e18404"
+URIParser = "30578b45-9adc-5946-b283-645ec420af67"
+
+[compat]
+Requires = "≥ 0.5.2"
+StringDistances = "≥ 0.3.0"
+julia = "≥ 0.7.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -15,11 +15,8 @@ between 0 and 1, and represent the quality of a given match. Matches are `DocObj
 accumulate lots of metadata about a binding (e.g. name, type, location etc.).
 
 `searchdocs` takes three keyword arguments:
-- `mod::String = "Main"` will restrict the search to the given module -- by default every loaded
-package will be searched.
-- `loaded::Bool = true` will search only packages in the current session, while `loaded = false`
-will search in *all* locally installed packages (actually only those in `Pkg.dir()`). Requires a
-call to `DocSeeker.createdocsdb()` beforehand.
+- `mod::String = "Main"` will restrict the search to the given module -- by default every loaded package will be searched.
+- `loaded::Bool = true` will search only packages in the current session, while `loaded = false` will search in *all* locally installed packages (actually only those in `Pkg.installed()`). Requires a call to `DocSeeker.createdocsdb()` beforehand.
 - `exportedonly::Bool = false` will search all names a module has, while `exportedonly=true`
 only takes exported names into consideration.
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,0 @@
-julia 0.7-beta
-Hiccup
-StringDistances 0.3
-URIParser
-Requires 0.5.2
-IterTools

--- a/src/static.jl
+++ b/src/static.jl
@@ -47,6 +47,7 @@ end
 
 function _createdocsdb(pkg)
   try
+    # @TODO: run this function in `Main` module and suppress package dependencies warning
     @eval using $(Symbol(pkg))
   catch err
     @error err

--- a/test/dynamicsearch.jl
+++ b/test/dynamicsearch.jl
@@ -1,0 +1,30 @@
+import DocSeeker: dynamicsearch
+
+function firstN(matches, desired, N = 3)
+  binds = map(x -> x[2].name, matches[1:N])
+  for d in desired
+    if !(d in binds)
+      return false
+    end
+  end
+  return true
+end
+
+@testset "dynamicsearch" begin
+  @test firstN(dynamicsearch("sine"), ["sin", "sind", "asin"], 20)
+  @test firstN(dynamicsearch("regular expression"), ["match", "eachmatch", "replace"], 20)
+
+  @test dynamicsearch("Real")[1][2].name == "Real"
+  @test length(dynamicsearch("Real")[1][2].text) > 0
+  @test dynamicsearch("regex")[1][2].name == "Regex"
+
+  let downloadsearch = dynamicsearch("download")
+    dfound = 0
+    for d in downloadsearch
+      if d[2].name == "download" && d[2].mod == "Base"
+        dfound += 1
+      end
+    end
+    @test dfound == 1
+  end
+end

--- a/test/finddocs.jl
+++ b/test/finddocs.jl
@@ -1,5 +1,11 @@
 import DocSeeker: baseURL, finddocsURL, readmepath
 
-@test baseURL(finddocsURL("base")) == "https://docs.julialang.org"
+@testset "finddocs" begin
+    @testset "finddocsURL" begin
+        @test baseURL(finddocsURL("base")) == "https://docs.julialang.org"
+    end
 
-@test readmepath("DocSeeker") == abspath(joinpath(@__DIR__, "..", "README.md"))
+    @testset "readmepath" begin
+        @test readmepath("DocSeeker") == abspath(joinpath(@__DIR__, "..", "README.md"))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,35 +1,5 @@
 using DocSeeker
 using Test
 
-import DocSeeker: dynamicsearch
-
-function firstN(matches, desired, N = 3)
-  binds = map(x -> x[2].name, matches[1:N])
-  for d in desired
-    if !(d in binds)
-      return false
-    end
-  end
-  return true
-end
-
-@test firstN(dynamicsearch("sine"), ["sin", "sind", "asin"], 20)
-
-@test firstN(dynamicsearch("regular expression"), ["match", "eachmatch", "replace"], 20)
-
-@test dynamicsearch("Real")[1][2].name == "Real"
-@test length(dynamicsearch("Real")[1][2].text) > 0
-
-let downloadsearch = dynamicsearch("download")
-  dfound = 0
-  for d in downloadsearch
-    if d[2].name == "download" && d[2].mod == "Base"
-      dfound += 1
-    end
-  end
-  @test dfound == 1
-end
-
-@test dynamicsearch("regex")[1][2].name == "Regex"
-
+include("dynamicsearch.jl")
 include("finddocs.jl")


### PR DESCRIPTION
## Purposes

update this package: maybe commits message says all what I have done

## Probs

I'm still not sure for how to handle the warning below when calling `createdocdb`:
```
┌ Warning: Package DocSeeker does not have APipe in its dependencies:
│ - If you have DocSeeker checked out for development and have
│   added Apipe as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with DocSeeker
└ Loading APipe into DocSeeker from project dependency, future warnings for DocSeeker are suppressed.
```

## Refs 

- closes #9 
- closes #8 
